### PR TITLE
incremental reading of files for steps where we don't need everything

### DIFF
--- a/src/clm/commands/inner_tabulate_molecules.py
+++ b/src/clm/commands/inner_tabulate_molecules.py
@@ -5,7 +5,7 @@ from tqdm import tqdm
 from rdkit import Chem
 from rdkit.Chem import Descriptors, rdMolDescriptors
 
-from clm.functions import read_file, clean_mol
+from clm.functions import read_file, read_file_incremental, clean_mol
 
 # suppress rdkit errors
 from rdkit import rdBase
@@ -42,10 +42,10 @@ def tabulate_molecules(input_file, train_file, representation, output_file):
     os.makedirs(os.path.dirname(output_file), exist_ok=True)
 
     train_smiles = read_file(train_file)
-    sampled_smiles = read_file(input_file)
+    sampled_smiles = read_file_incremental(input_file, max_lines=1000)
 
     new_smiles = []
-    for line in tqdm(sampled_smiles, total=len(sampled_smiles)):
+    for i, line in enumerate(tqdm(sampled_smiles)):
         *_, smile = line.split(",")
 
         # input file may have empty value for smile

--- a/src/clm/functions.py
+++ b/src/clm/functions.py
@@ -131,16 +131,18 @@ def get_rdkit_fingerprints(mols, include_none=False):
 
 
 def read_file(smiles_file, max_lines=None):
-    lines = []
-    with open(smiles_file, "r") as f:
-        for i, line in enumerate(f):
-            lines.append(line.strip())
-            if max_lines is not None and i + 1 == max_lines:
-                break
-
+    lines = [line for line in read_file_incremental(smiles_file, max_lines)]
     lines_array = np.array(lines)
-
     return lines_array
+
+
+def read_file_incremental(input_file, max_lines=None):
+    count = 0
+    for line in open(input_file, "r").readlines():
+        yield line.strip()
+        count += 1
+        if max_lines is not None and count == max_lines:
+            return
 
 
 def write_smiles(smiles, smiles_file, mode="w"):


### PR DESCRIPTION
For `inner_tabulate_molecules`, memory spikes up quite a bit when we're reading the input smiles. Since we're going to be processing them one-by-one anyway, using a generator helps there. We lose track of the total no. of lines this way, but I think in this case it's a small price to pay.

We can use this at other places where we see fit.

May or may not solve the problem of `OOM` on this step (I'm rerunning it by doubling the memory to 64M on the  clusters).