### PR TITLE
Fixed some minor bugs 

### DIFF
--- a/snakemake/Snakefile
+++ b/snakemake/Snakefile
@@ -355,7 +355,7 @@ rule write_structural_prior_CV_overall:
         train_file=f"{OUTPUT_DIR}/{{enum_factor}}/prior/inputs/train_{{dataset}}_{{repr}}_all.smi",
         test_file=f"{OUTPUT_DIR}/{{enum_factor}}/prior/inputs/test_{{dataset}}_{{repr}}_all.smi",
         pubchem_file=config['pubchem_tsv_file'],
-        sample_file=expand(f"{OUTPUT_DIR}/{{enum_factor}}/prior/samples/{{dataset}}_{{repr}}_processed_{{metric}}.csv", metric=METRICS, allow_missing=True)
+        sample_file=f"{OUTPUT_DIR}/{{enum_factor}}/prior/samples/{{dataset}}_{{repr}}_processed_{{metric}}.csv"
     output:
         ranks_file=f"{OUTPUT_DIR}/{{enum_factor}}/prior/structural_prior/{{dataset}}_{{repr}}_all_{{metric}}_CV_ranks_structure.csv",
         tc_file=f"{OUTPUT_DIR}/{{enum_factor}}/prior/structural_prior/{{dataset}}_{{repr}}_all_{{metric}}_CV_tc.csv"

--- a/src/clm/commands/inner_process_tabulated_molecules.py
+++ b/src/clm/commands/inner_process_tabulated_molecules.py
@@ -41,7 +41,7 @@ def process_tabulated_molecules(input_file, cv_files, output_file, summary_fn):
         cv_dat = cv_dat[cv_dat["smiles"].isin(uniq_smiles)]
 
         if not cv_dat.empty:
-            data[cv_dat["smiles"], fold_idx] = np.nan
+            data.loc[cv_dat["smiles"], fold_idx] = np.nan
 
     # Optionally normalize by total sampling frequency
     if summary_fn == "fp10k":


### PR DESCRIPTION
- Rule  `write_structural_prior_CV_overall` was expecting sample files for all three metrics at the same time. '
- One of the lines in `inner_process_tabulated_molecules.py` was trying to hash a `Series`. 