### PR TITLE
Vb/snakemake resources

### DIFF
--- a/snakemake/Snakefile
+++ b/snakemake/Snakefile
@@ -132,7 +132,7 @@ rule train_models_RNN:
         loss_file=f"{OUTPUT_DIR}/{{enum_factor}}/prior/models/{{dataset}}_{{repr}}_{{fold}}_{{seed}}_loss.csv"
     resources:
         mem_mb=32000,
-        runtime=MODEL_PARAMS["max_epochs"]*120,
+        runtime=MODEL_PARAMS["max_epochs"]*15,
         slurm_extra="--gres=gpu:1"
     shell:
             'clm inner_train_models_RNN '
@@ -197,8 +197,8 @@ rule tabulate_molecules:
     output:
         output_file=f"{OUTPUT_DIR}/{{enum_factor}}/prior/samples/{{dataset}}_{{repr}}_{{fold}}_{{seed}}_samples_masses.csv",
     resources:
-        mem_mb=4000,
-        runtime=MODEL_PARAMS["sample_mols"]//1000,
+        mem_mb=32000,
+        runtime=MODEL_PARAMS["sample_mols"]//100000,
     shell:
         'clm inner_tabulate_molecules '
         '--input_file {input.input_file} '
@@ -218,7 +218,7 @@ rule collect_tabulated_molecules:
         output_file=f"{OUTPUT_DIR}/{{enum_factor}}/prior/samples/{{dataset}}_{{repr}}_{{fold}}_unique_masses.csv",
     resources:
         mem_mb=4000,
-        runtime=MODEL_PARAMS["sample_mols"]//1000,
+        runtime=MODEL_PARAMS["sample_mols"]//1000000,
     shell:
         'clm inner_collect_tabulated_molecules '
         '--input_files {input.input_files} '
@@ -243,8 +243,8 @@ rule process_tabulated_molecules:
     output:
         output_file=f"{OUTPUT_DIR}/{{enum_factor}}/prior/samples/{{dataset}}_{{repr}}_processed_{{metric}}.csv",
     resources:
-        mem_mb=4000,
-        runtime=MODEL_PARAMS["sample_mols"]//1000,
+        mem_mb=64000,
+        runtime=MODEL_PARAMS["sample_mols"]//100000,
     shell:
         'clm inner_process_tabulated_molecules '
         '--input_file {input.input_file} '
@@ -287,7 +287,7 @@ rule write_structural_prior_CV:
          tc_file=f"{OUTPUT_DIR}/{{enum_factor}}/prior/structural_prior/{{dataset}}_{{repr}}_{{fold}}_CV_tc.csv"
     resources:
         mem_mb=32000,
-        runtime=180,
+        runtime=MODEL_PARAMS["sample_mols"]//10000,
     shell:
         'clm inner_write_structural_prior_CV '
         '--ranks_file {output.ranks_file} '
@@ -326,7 +326,7 @@ rule write_formula_prior_CV:
          ranks_file=f"{OUTPUT_DIR}/{{enum_factor}}/prior/structural_prior/{{dataset}}_{{repr}}_{{fold}}_CV_ranks_formula.csv"
     resources:
         mem_mb=32000,
-        runtime=180,
+        runtime=MODEL_PARAMS["sample_mols"]//10000,
     shell:
         'clm inner_write_formula_prior_CV '
         '--ranks_file {output.ranks_file} '
@@ -366,8 +366,8 @@ rule write_structural_prior_CV_overall:
         ranks_file=f"{OUTPUT_DIR}/{{enum_factor}}/prior/structural_prior/{{dataset}}_{{repr}}_all_{{metric}}_CV_ranks_structure.csv",
         tc_file=f"{OUTPUT_DIR}/{{enum_factor}}/prior/structural_prior/{{dataset}}_{{repr}}_all_{{metric}}_CV_tc.csv"
     resources:
-        mem_mb=32000,
-        runtime=180,
+        mem_mb=64000,
+        runtime=MODEL_PARAMS["sample_mols"]/5000,
     shell:
         'clm inner_write_structural_prior_CV '
         '--ranks_file {output.ranks_file} '

--- a/snakemake/Snakefile
+++ b/snakemake/Snakefile
@@ -5,6 +5,7 @@ threads: 1
 # -----------------------------------------------------------------------------
 DATASET = os.path.splitext(os.path.basename(config["dataset"]))[0]
 REPRESENTATIONS = config["representations"]
+REPRESENTATIONS_NO_SELFIES = [r for r in REPRESENTATIONS if r!="SELFIES"]
 SEEDS = config["seeds"]
 FOLDS = config["folds"]
 ENUM_FACTORS = config["enum_factors"]
@@ -30,13 +31,13 @@ rule all:
     input:
         output_file=expand(f"{OUTPUT_DIR}/{{enum_factor}}/prior/samples/{{dataset}}_{{repr}}_processed_{{metric}}.csv", enum_factor=ENUM_FACTORS, dataset=DATASET, repr=REPRESENTATIONS, metric=METRICS),
         ranks_file_formula=expand(f"{OUTPUT_DIR}/{{enum_factor}}/prior/structural_prior/{{dataset}}_{{repr}}_{{fold}}_CV_ranks_formula.csv",
-                       enum_factor=ENUM_FACTORS, dataset=DATASET, repr=REPRESENTATIONS, seed=SEEDS, fold=range(FOLDS)),
+                       enum_factor=ENUM_FACTORS, dataset=DATASET, repr=REPRESENTATIONS_NO_SELFIES, seed=SEEDS, fold=range(FOLDS)),
         ranks_file_structure=expand(f"{OUTPUT_DIR}/{{enum_factor}}/prior/structural_prior/{{dataset}}_{{repr}}_{{fold}}_CV_ranks_structure.csv",
-                   enum_factor=ENUM_FACTORS, dataset=DATASET, repr=REPRESENTATIONS, seed=SEEDS, fold=range(FOLDS)),
+                   enum_factor=ENUM_FACTORS, dataset=DATASET, repr=REPRESENTATIONS_NO_SELFIES, seed=SEEDS, fold=range(FOLDS)),
         tc_file=expand(f"{OUTPUT_DIR}/{{enum_factor}}/prior/structural_prior/{{dataset}}_{{repr}}_{{fold}}_CV_tc.csv",
-                   enum_factor=ENUM_FACTORS, dataset=DATASET, repr=REPRESENTATIONS, seed=SEEDS, fold=range(FOLDS)),
+                   enum_factor=ENUM_FACTORS, dataset=DATASET, repr=REPRESENTATIONS_NO_SELFIES, seed=SEEDS, fold=range(FOLDS)),
         ranks_file_overall = expand(f"{OUTPUT_DIR}/{{enum_factor}}/prior/structural_prior/{{dataset}}_{{repr}}_all_{{metric}}_CV_ranks_structure.csv",
-            enum_factor=ENUM_FACTORS, dataset=DATASET, repr=REPRESENTATIONS, metric=METRICS),
+            enum_factor=ENUM_FACTORS, dataset=DATASET, repr=REPRESENTATIONS_NO_SELFIES, metric=METRICS),
         tc_file_overall = expand(f"{OUTPUT_DIR}/{{enum_factor}}/prior/structural_prior/{{dataset}}_{{repr}}_all_{{metric}}_CV_tc.csv",
             enum_factor=ENUM_FACTORS,dataset=DATASET,repr=REPRESENTATIONS,metric=METRICS)
 
@@ -132,7 +133,7 @@ rule train_models_RNN:
         loss_file=f"{OUTPUT_DIR}/{{enum_factor}}/prior/models/{{dataset}}_{{repr}}_{{fold}}_{{seed}}_loss.csv"
     resources:
         mem_mb=32000,
-        runtime=MODEL_PARAMS["max_epochs"]*15,
+        runtime=15+MODEL_PARAMS["max_epochs"]*15,
         slurm_extra="--gres=gpu:1"
     shell:
             'clm inner_train_models_RNN '
@@ -168,7 +169,7 @@ rule sample_molecules_RNN:
         output_file=f"{OUTPUT_DIR}/{{enum_factor}}/prior/samples/{{dataset}}_{{repr}}_{{fold}}_{{seed}}_samples.csv"
     resources:
         mem_mb=1000,
-        runtime=MODEL_PARAMS["sample_mols"]//10000,
+        runtime=15+MODEL_PARAMS["sample_mols"]//10000,
         slurm_extra="--gres=gpu:1"
     shell:
         'clm inner_sample_molecules_RNN '
@@ -198,7 +199,7 @@ rule tabulate_molecules:
         output_file=f"{OUTPUT_DIR}/{{enum_factor}}/prior/samples/{{dataset}}_{{repr}}_{{fold}}_{{seed}}_samples_masses.csv",
     resources:
         mem_mb=32000,
-        runtime=MODEL_PARAMS["sample_mols"]//100000,
+        runtime=15+MODEL_PARAMS["sample_mols"]//100000,
     shell:
         'clm inner_tabulate_molecules '
         '--input_file {input.input_file} '
@@ -218,7 +219,7 @@ rule collect_tabulated_molecules:
         output_file=f"{OUTPUT_DIR}/{{enum_factor}}/prior/samples/{{dataset}}_{{repr}}_{{fold}}_unique_masses.csv",
     resources:
         mem_mb=4000,
-        runtime=MODEL_PARAMS["sample_mols"]//1000000,
+        runtime=15+MODEL_PARAMS["sample_mols"]//1000000,
     shell:
         'clm inner_collect_tabulated_molecules '
         '--input_files {input.input_files} '
@@ -244,7 +245,7 @@ rule process_tabulated_molecules:
         output_file=f"{OUTPUT_DIR}/{{enum_factor}}/prior/samples/{{dataset}}_{{repr}}_processed_{{metric}}.csv",
     resources:
         mem_mb=64000,
-        runtime=MODEL_PARAMS["sample_mols"]//100000,
+        runtime=15+MODEL_PARAMS["sample_mols"]//100000,
     shell:
         'clm inner_process_tabulated_molecules '
         '--input_file {input.input_file} '
@@ -287,7 +288,7 @@ rule write_structural_prior_CV:
          tc_file=f"{OUTPUT_DIR}/{{enum_factor}}/prior/structural_prior/{{dataset}}_{{repr}}_{{fold}}_CV_tc.csv"
     resources:
         mem_mb=32000,
-        runtime=MODEL_PARAMS["sample_mols"]//10000,
+        runtime=15+MODEL_PARAMS["sample_mols"]//10000,
     shell:
         'clm inner_write_structural_prior_CV '
         '--ranks_file {output.ranks_file} '
@@ -326,7 +327,7 @@ rule write_formula_prior_CV:
          ranks_file=f"{OUTPUT_DIR}/{{enum_factor}}/prior/structural_prior/{{dataset}}_{{repr}}_{{fold}}_CV_ranks_formula.csv"
     resources:
         mem_mb=32000,
-        runtime=MODEL_PARAMS["sample_mols"]//10000,
+        runtime=15+MODEL_PARAMS["sample_mols"]//10000,
     shell:
         'clm inner_write_formula_prior_CV '
         '--ranks_file {output.ranks_file} '
@@ -367,7 +368,7 @@ rule write_structural_prior_CV_overall:
         tc_file=f"{OUTPUT_DIR}/{{enum_factor}}/prior/structural_prior/{{dataset}}_{{repr}}_all_{{metric}}_CV_tc.csv"
     resources:
         mem_mb=64000,
-        runtime=MODEL_PARAMS["sample_mols"]/5000,
+        runtime=15+MODEL_PARAMS["sample_mols"]//5000,
     shell:
         'clm inner_write_structural_prior_CV '
         '--ranks_file {output.ranks_file} '


### PR DESCRIPTION
The changes we discussed yesterday. Adding `15+` to `runtime` does work (workflow was failing for a different reason).
It turns out that `config_fast.json` is still failing for me with a `TIMEOUT`, so this may need further tweaking for the min time given to steps, but this can be merged anyway, in preparation for a run on another real dataset.