### PR TITLE
Introducing plot command and plot for calculate outcomes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,9 @@ dependencies = [
     "selfies",
     "snakemake",
     "torch",
-    "tqdm"
+    "tqdm",
+    "seaborn",
+    "matplotlib"
 ]
 dynamic = ["version"]
 

--- a/src/clm/__main__.py
+++ b/src/clm/__main__.py
@@ -21,6 +21,7 @@ from clm.commands import (
     write_outcome_distr,
     calculate_outcome_distrs,
     add_carbon,
+    plot,
 )
 
 
@@ -50,6 +51,7 @@ def main():
         write_outcome_distr,
         calculate_outcome_distrs,
         add_carbon,
+        plot,
     )
 
     subparsers = parser.add_subparsers(title="Choose a command")

--- a/src/clm/commands/plot.py
+++ b/src/clm/commands/plot.py
@@ -7,7 +7,7 @@ def add_args(parser):
         "evaluation_type",
         type=str,
         help="Type of evaluation you want figures of. Valid options are:  \n"
-             " calculate_outcomes",
+        " calculate_outcomes",
     )
     parser.add_argument(
         "--outcome_dir",

--- a/src/clm/commands/plot.py
+++ b/src/clm/commands/plot.py
@@ -1,0 +1,43 @@
+import argparse
+from clm.plot.calculate_outcomes import plot as calculate_outcomes
+
+
+def add_args(parser):
+    parser.add_argument(
+        "evaluation_type",
+        type=str,
+        help="Type of evaluation you want figures of. Valid options are:  \n"
+             " calculate_outcomes",
+    )
+    parser.add_argument(
+        "--outcome_dir",
+        type=str,
+        required=True,
+        help="Path to directory where all the model evaluation files are saved ",
+    )
+    parser.add_argument(
+        "--output_dir",
+        type=str,
+        required=True,
+        help="Path to directory to save resulting images(s) at",
+    )
+    return parser
+
+
+def plot(evaluation_type, outcome_dir, output_dir):
+    if evaluation_type == "calculate_outcomes":
+        calculate_outcomes(outcome_dir, output_dir)
+
+
+def main(args):
+    plot(
+        evaluation_type=args.evaluation_type,
+        outcome_dir=args.outcome_dir,
+        output_dir=args.output_dir,
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    args = add_args(parser).parse_args()
+    main(args)

--- a/src/clm/plot/calculate_outcomes.py
+++ b/src/clm/plot/calculate_outcomes.py
@@ -1,0 +1,124 @@
+import argparse
+import glob
+
+import pandas as pd
+from pathlib import Path
+import os
+from matplotlib import pyplot as plt
+import seaborn as sns
+
+
+def add_args(parser):
+    parser.add_argument(
+        "--outcome_dir",
+        type=str,
+        help="Path to directory where all the model evaluation files are saved ",
+    )
+    parser.add_argument(
+        "--output_dir",
+        type=str,
+        help="Path to directory to save resulting images(s) at",
+    )
+    return parser
+
+
+def plot(outcome_dir, output_dir):
+
+    # Make output directory if it doesn't exist yet
+    os.makedirs(output_dir, exist_ok=True)
+
+    freq_map = {
+        "1-1": "1",
+        "2-2": "2",
+        "3-10": "3-10",
+        "11-30": "11-30",
+        "31-100": "31-100",
+        "101-": ">100",
+    }
+    plot_types = {
+        "% novel",
+        "% unique",
+        "% valid",
+        "External diversity",
+        "External nearest-neighbor Tc",
+        "Frechet ChemNet distance",
+        "Internal diversity",
+        "Internal nearest-neighbor Tc",
+        "Jensen-Shannon distance, # of aliphatic rings",
+        "Jensen-Shannon distance, # of aromatic rings",
+        "Jensen-Shannon distance, # of rings",
+        "Jensen-Shannon distance, % rotatable bonds",
+        "Jensen-Shannon distance, % sp3 carbons",
+        "Jensen-Shannon distance, % stereocenters",
+        "Jensen-Shannon distance, Bertz TC",
+        "Jensen-Shannon distance, MWs",
+        "Jensen-Shannon distance, Murcko scaffolds",
+        "Jensen-Shannon distance, NP score",
+        "Jensen-Shannon distance, QED",
+        "Jensen-Shannon distance, SA score",
+        "Jensen-Shannon distance, TPSA",
+        "Jensen-Shannon distance, atoms",
+        "Jensen-Shannon distance, hydrogen acceptors",
+        "Jensen-Shannon distance, hydrogen donors",
+        "Jensen-Shannon distance, logP",
+        "KL divergence, atoms",
+        "Wasserstein distance, atoms",
+        "n_mols",
+    }
+
+    outcome_files = glob.glob(f"{outcome_dir}/*calculate_outcomes.csv")
+    outcome = pd.concat(
+        [pd.read_csv(outcome_file, delimiter=",") for outcome_file in outcome_files]
+    )
+
+    # Split the data frame by outcomes and extract the one chosen to be plotted
+    split_outcomes = {df["outcome"].iloc[0]: df for _, df in outcome.groupby("outcome")}
+
+    # Plot every figure possible
+    for plot_type in plot_types:
+        chosen_outcome = split_outcomes[plot_type]
+
+        # Generate a dictionary of frequency bin and respective value to be plotted
+        split_freq = {
+            freq_map[df["bin"].iloc[0]]: list(df["value"])
+            for df in [
+                chosen_outcome[chosen_outcome["bin"] == i] for i in freq_map.keys()
+            ]
+        }
+
+        data = list(split_freq.values())
+        labels = list(split_freq.keys())
+
+        sns.violinplot(
+            data=data,
+            palette=sns.color_palette("pastel"),
+            linecolor="auto",
+            width=0.4,
+            inner="box",
+            inner_kws={"box_width": 3},
+            native_scale=True,
+        )
+
+        plt.title(plot_type)
+        plt.ylabel(plot_type)
+        plt.xlabel("Frequency")
+        plt.xticks(list(range(len(labels))), labels)
+
+        file_name = Path(output_dir) / plot_type
+        plt.savefig(file_name)
+
+        # Clear the previous figure
+        plt.clf()
+
+
+def main(args):
+    plot(
+        outcome_dir=args.outcome_dir,
+        output_dir=args.output_dir,
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    args = add_args(parser).parse_args()
+    main(args)

--- a/tests/test_snakemake.py
+++ b/tests/test_snakemake.py
@@ -17,7 +17,7 @@ pubchem_tsv_file = base_dir / "tests/test_data/PubChem_truncated.tsv"
 def test_snakemake():
     with tempfile.TemporaryDirectory() as temp_dir:
         success = snakemake.snakemake(
-            snakefile=snakefile,
+            snakefile=str(snakefile),
             cores=1,
             configfiles=[config_file],
             config={


### PR DESCRIPTION
Introducing plot command instead of `--plot` option. Running the following command after generating the model evaluation files will generate all the figures relating a particular evaluation (calculate_outcomes in this case): 
```
clm plot calculate_outcomes --outcome_dir /path/to/model_evaluation/ --output_dir /path/to/figures
```

