### PR TITLE
Fixed a bug in train_discriminator

### DIFF
--- a/src/clm/commands/train_discriminator.py
+++ b/src/clm/commands/train_discriminator.py
@@ -71,13 +71,16 @@ def train_discriminator(train_file, sample_file, output_file, seed, max_mols=100
     )
 
     np_fps = []
-    for smile in tqdm(np.concatenate((train_smiles, novel_smiles), axis=0)):
+    labels = []
+    for idx, smile in tqdm(
+        enumerate(np.concatenate((train_smiles, novel_smiles), axis=0))
+    ):
         if (fp := calculate_fingerprint(smile)) is not None:
             arr = np.zeros((1,))
             DataStructs.ConvertToNumpyArray(fp, arr)
             np_fps.append(arr)
 
-    labels = [1] * len(train_smiles) + [0] * len(novel_smiles)
+            labels.append(1) if idx < len(train_smiles) else labels.append(0)
 
     # Split into train/test folds
     X_train, X_test, y_train, y_test = train_test_split(


### PR DESCRIPTION
`train_smiles` and `novel_smiles` have likelihood of having an invalid SMILES as its element. Unlike `np_fps` which has no representation for those invalid SMILES. If a molecule is found to be invalid, it's ignored ([line 49](https://github.com/vineetbansal/CLM/blob/31e6e2eb7af85daacf8e3be64317b4bdefc67824/src/clm/commands/train_discriminator.py#L49C1-L51C1)).  
This wasn't being taken into account when creating labels `labels = [1] * len(train_smiles) + [0] * len(novel_smiles)`.  Fixed it now, by appending values to `labels` inside of the loop that's appending values to `np_fps`. 