### PR TITLE
more logging; true randomization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "pulp<2.8.0",
     "rdkit",
     "scikit-learn",
-    "scipy<1.12",
+    "scipy==1.11.1",
     "selfies",
     "snakemake",
     "torch",

--- a/src/clm/commands/calculate_outcomes.py
+++ b/src/clm/commands/calculate_outcomes.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 import scipy.stats
 from fcd_torch import FCD
+import logging
 from rdkit import Chem
 from rdkit.Chem import Descriptors, Lipinski, RDKFingerprint
 from rdkit.Chem.GraphDescriptors import BertzCT
@@ -33,6 +34,7 @@ from clm.functions import (
 
 rdBase.DisableLog("rdApp.error")
 fscore = npscorer.readNPModel()
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -96,8 +98,15 @@ molecular_properties = {
 
 def smile_properties_dataframe(input_file, max_smiles=None):
     data = []
-    for smile in read_file(
-        input_file, smile_only=True, stream=True, max_lines=max_smiles
+    for i, smile in enumerate(
+        read_file(
+            input_file,
+            smile_only=True,
+            stream=True,
+            max_lines=max_smiles,
+            randomize=True,
+        ),
+        start=1,
     ):
         if (mol := clean_mol(smile, raise_error=False)) is not None:
             row = tuple(fun(mol) for fun in molecular_properties.values())
@@ -105,6 +114,8 @@ def smile_properties_dataframe(input_file, max_smiles=None):
             row = tuple([None] * len(molecular_properties))
 
         data.append((smile,) + row)
+        if i % 1_000 == 0:
+            logger.info(f"Processed {i} SMILES")
 
     df = pd.DataFrame(data, columns=["smile"] + list(molecular_properties.keys()))
     return df
@@ -124,21 +135,29 @@ def calculate_probabilities(*dicts):
 
 
 def get_dataframes(train_file, sampled_file, max_orig_mols=None):
+    logger.info(f"Reading training smiles from {train_file}")
     train_df = smile_properties_dataframe(train_file)
+
+    logger.info(f"Reading sample smiles from {sampled_file}")
     sample_smiles_df = smile_properties_dataframe(
         sampled_file, max_smiles=max_orig_mols
     )
 
     sample_smiles_df["is_valid"] = sample_smiles_df.apply(
-        lambda row: clean_mol(row["smile"], raise_error=False) is not None, axis=1
+        lambda row: row["canonical_smile"] is not None, axis=1
     )
+    n_valid_smiles = sample_smiles_df["is_valid"].sum()
+    logger.info(f"{n_valid_smiles} valid SMILES out of {len(sample_smiles_df)}")
 
     sample_smiles_df["is_novel"] = sample_smiles_df.apply(
         lambda row: row["smile"] not in train_df["smile"], axis=1
     )
+    n_novel_smiles = sample_smiles_df["is_novel"].sum()
+    logger.info(f"{n_novel_smiles} novel SMILES out of {len(sample_smiles_df)}")
 
-    # Re-read the sample_file to obtain bin/other information, and merge
+    logger.info("Re-reading sample file to obtain bin/other information")
     sample_bin_df = pd.read_csv(sampled_file)
+    logger.info("Merging bin information")
     sample_df = sample_smiles_df.merge(
         sample_bin_df, left_on="smile", right_on="smiles"
     )
@@ -156,6 +175,7 @@ def calculate_outcomes_dataframe(sample_df, train_df):
 
     out = []
     for bin, bin_df in sample_df.groupby("bin"):
+        logger.info(f"Calculating outcomes for bin {bin}")
         bin_df = bin_df.reset_index(drop=True)
         element_distribution = dict(
             zip(
@@ -260,6 +280,7 @@ def calculate_outcomes(
     set_seed(seed)
     train_df, sample_df = get_dataframes(train_file, sampled_file, max_orig_mols)
 
+    logger.info("Calculating outcomes")
     out = calculate_outcomes_dataframe(sample_df, train_df)
 
     # `input_file` column added for legacy reasons

--- a/src/clm/commands/calculate_outcomes.py
+++ b/src/clm/commands/calculate_outcomes.py
@@ -104,7 +104,7 @@ def smile_properties_dataframe(input_file, max_smiles=None):
             smile_only=True,
             stream=True,
             max_lines=max_smiles,
-            randomize=True,
+            randomize=False,
         ),
         start=1,
     ):

--- a/src/clm/commands/inner_prep_outcomes_freq.py
+++ b/src/clm/commands/inner_prep_outcomes_freq.py
@@ -1,5 +1,4 @@
 import argparse
-import io
 import pandas as pd
 from clm.functions import set_seed, seed_type
 
@@ -27,7 +26,7 @@ def prep_outcomes_freq(samples, max_molecules, output_file=None, seed=None):
     set_seed(seed)
 
     # Samples can be a csv file or a dataframe
-    data = pd.read_csv(samples) if isinstance(samples, io.TextIOBase) else samples
+    data = pd.read_csv(samples) if isinstance(samples, str) else samples
 
     # TODO: make this process dynamic later
     frequency_ranges = [(1, 1), (2, 2), (3, 10), (11, 30), (31, 100), (101, None)]

--- a/src/clm/functions.py
+++ b/src/clm/functions.py
@@ -198,7 +198,7 @@ def read_file(
         return iter(data) if stream else data
     else:
         gen = _read_file(smiles_file, max_lines, smile_only)
-        return gen if stream else list(gen)
+        return gen if stream else np.array(list(gen))
 
 
 def write_smiles(smiles, smiles_file, mode="w"):

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,0 +1,75 @@
+import contextlib
+from pathlib import Path
+import pytest
+import numpy as np
+from clm.functions import read_file
+
+
+base_dir = Path(__file__).parent.parent
+dataset = base_dir / "tests/test_data/LOTUS_truncated.txt"
+
+
+@contextlib.contextmanager
+def local_seed(seed):
+    current_state = np.random.get_state()
+    np.random.seed(seed)
+    try:
+        yield
+    finally:
+        np.random.set_state(current_state)
+
+
+def test_read_file_all():
+    data = read_file(
+        dataset, max_lines=None, smile_only=False, stream=False, randomize=False
+    )
+    assert len(data) == 2501
+
+
+def test_read_file_5():
+    data = read_file(
+        dataset, max_lines=5, smile_only=False, stream=False, randomize=False
+    )
+    assert len(data) == 5
+    assert data[3] == "CS(=O)(=O)C=CCO"  # Line 4
+
+
+def test_read_file_stream():
+    data = read_file(
+        dataset, max_lines=None, smile_only=False, stream=True, randomize=False
+    )
+    with pytest.raises(TypeError):
+        len(data)
+    assert len(list(data)) == 2501
+
+
+def test_read_file_stream_5():
+    data = read_file(
+        dataset, max_lines=5, smile_only=False, stream=True, randomize=False
+    )
+    with pytest.raises(TypeError):
+        len(data)
+    assert len(list(data)) == 5
+
+
+def test_read_file_5_randomize():
+    with local_seed(1234):
+        data = read_file(
+            dataset, max_lines=5, smile_only=False, stream=False, randomize=True
+        )
+        assert len(data) == 5
+        assert data[3] == "CC1(C)C=Cc2c(cc(CO)c(C(=O)O)c2O)O1"  # Line 517
+
+
+def test_read_file_stream_5_randomize():
+    with local_seed(1234):
+        data = read_file(
+            dataset, max_lines=5, smile_only=False, stream=True, randomize=True
+        )
+
+    with pytest.raises(TypeError):
+        len(data)
+
+    data = list(data)
+    assert len(data) == 5
+    assert data[3] == "CC1(C)C=Cc2c(cc(CO)c(C(=O)O)c2O)O1"  # Line 517


### PR DESCRIPTION
As I'm going through the process of running evaluation steps locally, I'll be adding more extensive logging to some steps to give an idea on the progress. In addition:

- support true randomization for `--max_orig_mols` (its cheap to read the entire file in memory in case we do need true randomization of rows). Tests for these.
- pinned `scipy` to `1.11.1` (I'm not seeing any FCD errors with this locally).